### PR TITLE
♻️ update podspec to automatically reflect `package.json` values

### DIFF
--- a/CapacitorCommunityCapacitorGooglemapsNative.podspec
+++ b/CapacitorCommunityCapacitorGooglemapsNative.podspec
@@ -1,15 +1,18 @@
+require 'json'
 
-  Pod::Spec.new do |s|
-    s.name = 'CapacitorCommunityCapacitorGooglemapsNative'
-    s.version = '1.0.2'
-    s.summary = 'Plugin using native Maps API for Android and iOS.'
-    s.license = 'MIT'
-    s.homepage = 'https://github.com/capacitor-community/capacitor-googlemaps-native'
-    s.author = 'Hemang Kumar'
-    s.source = { :git => 'https://github.com/capacitor-community/capacitor-googlemaps-native', :tag => s.version.to_s }
-    s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-    s.ios.deployment_target  = '12.0'
-    s.dependency 'Capacitor'
-    s.dependency 'GoogleMaps'
-    s.static_framework = true
-  end
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name = 'CapacitorCommunityCapacitorGooglemapsNative'
+  s.version = package['version']
+  s.summary = package['description']
+  s.license = package['license']
+  s.homepage = package['repository']['url']
+  s.author = package['author']
+  s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
+  s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
+  s.ios.deployment_target  = '12.0'
+  s.dependency 'Capacitor'
+  s.dependency 'GoogleMaps'
+  s.static_framework = true
+end


### PR DESCRIPTION
This commit reflects the way the new Capacitor CLI creates a podspec.

From now on you shouldn't need to touch the podspec, because it takes its values from the `package.json` automatically.