### PR TITLE
Added viewBounds function to return map view bounds of all corners in Lat/Lng

### DIFF
--- a/android/src/main/java/com/hemangkumar/capacitorgooglemaps/CapacitorGoogleMaps.java
+++ b/android/src/main/java/com/hemangkumar/capacitorgooglemaps/CapacitorGoogleMaps.java
@@ -431,12 +431,13 @@ public class CapacitorGoogleMaps extends Plugin implements OnMapReadyCallback, G
         getBridge().executeOnMainThread(new Runnable() {
             @Override
             public void run() {
+                JSObject result = new JSObject();
                 JSObject bounds = new JSObject();        
                 JSObject farLeft = new JSObject();
                 JSObject farRight = new JSObject();
                 JSObject nearLeft = new JSObject();
                 JSObject nearRight = new JSObject();
-                
+
                 farLeft.put("latitude",googleMap.getProjection().getVisibleRegion().farLeft.latitude);
                 farLeft.put("longitude",googleMap.getProjection().getVisibleRegion().farLeft.longitude);
                 farRight.put("latitude",googleMap.getProjection().getVisibleRegion().farRight.latitude);
@@ -450,8 +451,9 @@ public class CapacitorGoogleMaps extends Plugin implements OnMapReadyCallback, G
                 bounds.put("farRight",farRight);
                 bounds.put("nearLeft",nearLeft);
                 bounds.put("nearRight",nearRight);
-
-                call.resolve(bounds);
+                result.put("bounds",bounds);
+                
+                call.resolve(result);
             }
         });
     }

--- a/android/src/main/java/com/hemangkumar/capacitorgooglemaps/CapacitorGoogleMaps.java
+++ b/android/src/main/java/com/hemangkumar/capacitorgooglemaps/CapacitorGoogleMaps.java
@@ -427,6 +427,36 @@ public class CapacitorGoogleMaps extends Plugin implements OnMapReadyCallback, G
     }
 
     @PluginMethod()
+    public void viewBounds(final PluginCall call) {
+        getBridge().executeOnMainThread(new Runnable() {
+            @Override
+            public void run() {
+                JSObject bounds = new JSObject();        
+                JSObject farLeft = new JSObject();
+                JSObject farRight = new JSObject();
+                JSObject nearLeft = new JSObject();
+                JSObject nearRight = new JSObject();
+                
+                farLeft.put("latitude",googleMap.getProjection().getVisibleRegion().farLeft.latitude);
+                farLeft.put("longitude",googleMap.getProjection().getVisibleRegion().farLeft.longitude);
+                farRight.put("latitude",googleMap.getProjection().getVisibleRegion().farRight.latitude);
+                farRight.put("longitude",googleMap.getProjection().getVisibleRegion().farRight.longitude);
+                nearLeft.put("latitude",googleMap.getProjection().getVisibleRegion().nearLeft.latitude);
+                nearLeft.put("longitude",googleMap.getProjection().getVisibleRegion().nearLeft.longitude);
+                nearRight.put("latitude",googleMap.getProjection().getVisibleRegion().nearRight.latitude);
+                nearRight.put("longitude",googleMap.getProjection().getVisibleRegion().nearRight.longitude);
+
+                bounds.put("farLeft",farLeft);
+                bounds.put("farRight",farRight);
+                bounds.put("nearLeft",nearLeft);
+                bounds.put("nearRight",nearRight);
+
+                call.resolve(bounds);
+            }
+        });
+    }
+
+    @PluginMethod()
     public void reverseGeocodeCoordinate(final PluginCall call) {
         final Double latitude = call.getDouble("latitude", 0.0);
         final Double longitude = call.getDouble("longitude", 0.0);

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -26,4 +26,5 @@ CAP_PLUGIN(CapacitorGoogleMaps, "CapacitorGoogleMaps",
            CAP_PLUGIN_METHOD(addCircle, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(enableCurrentLocation, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(myLocation, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(viewBounds, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -161,6 +161,35 @@ public class CapacitorGoogleMaps: CAPPlugin, GMSMapViewDelegate, GMSPanoramaView
 
     }
 
+    @objc func viewBounds(_ call: CAPPluginCall) {
+
+        DispatchQueue.main.async {
+            let bounds = self.mapViewController.GMapView.projection.visibleRegion();
+
+            call.resolve([
+                "bounds":[
+                    "farLeft": [
+                        "latitude": bounds.farLeft.latitude as Any,
+                        "longitude": bounds.farLeft.longitude as Any
+                    ],
+                    "farRight":[
+                        "latitude": bounds.farRight.latitude as Any,
+                        "longitude": bounds.farRight.longitude as Any
+                    ],
+                    "nearLeft":[
+                        "latitude": bounds.nearLeft.latitude as Any,
+                        "longitude": bounds.nearLeft.longitude as Any
+                    ],
+                    "nearRight":[
+                        "latitude": bounds.nearRight.latitude as Any,
+                        "longitude": bounds.nearRight.longitude as Any
+                    ]
+
+                ]
+            ])
+        }
+    }
+
     @objc func padding(_ call: CAPPluginCall) {
         let top = CGFloat(call.getFloat("top") ?? 0.0)
         let left = CGFloat(call.getFloat("left") ?? 0.0)

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,4 @@
-import { PluginListenerHandle } from "@capacitor/core";
+import { PluginListenerHandle } from '@capacitor/core';
 
 import { LatLng } from './types/common/latlng.interface';
 import { PolylineOptions } from './types/shapes/polyline.interface';
@@ -6,73 +6,62 @@ import { PolygonOptions } from './types/shapes/polygon.interface';
 import { CircleOptions } from './types/shapes/circle.interface';
 
 export interface CapacitorGoogleMapsPlugin {
-
   /** Creates map view and displays it */
   create(options: {
-    width: number,
-    height: number,
-    x: number,
-    y: number,
-    latitude?: number,
-    longitude?: number,
-    zoom?: number,
-    liteMode?: boolean,
+    width: number;
+    height: number;
+    x: number;
+    y: number;
+    latitude?: number;
+    longitude?: number;
+    zoom?: number;
+    liteMode?: boolean;
   }): Promise<any>;
 
   /** [iOS only] Initializes GoogleMaps with API key */
-  initialize(options: {
-    key: string,
-  }): Promise<any>;
+  initialize(options: { key: string }): Promise<any>;
 
   /** Adds a marker on the map */
   addMarker(options: {
-    latitude: number,
-    longitude: number,
-    opacity?: number,
-    title?: string,
-    snippet?: string,
-    isFlat?: boolean,
-    url?: string,
+    latitude: number;
+    longitude: number;
+    opacity?: number;
+    title?: string;
+    snippet?: string;
+    isFlat?: boolean;
+    url?: string;
   }): Promise<any>;
 
   /** Repositions the camera */
   setCamera(options: {
-    viewingAngle?: number,
-    bearing?: number,
-    zoom?: number,
-    latitude?: number,
-    longitude?: number,
-    animate?: boolean,
-    animationDuration?: number,
-    coordinates?: LatLng[],
+    viewingAngle?: number;
+    bearing?: number;
+    zoom?: number;
+    latitude?: number;
+    longitude?: number;
+    animate?: boolean;
+    animationDuration?: number;
+    coordinates?: LatLng[];
   }): Promise<any>;
 
   /** Sets the map type  */
-  setMapType(options: {
-    type: string,
-  }): Promise<any>;
+  setMapType(options: { type: string }): Promise<any>;
 
   /** Allows indoor maps to be enabled or disabled  */
-  setIndoorEnabled(options: {
-    enabled: boolean,
-  }): Promise<any>;
+  setIndoorEnabled(options: { enabled: boolean }): Promise<any>;
 
   /** Allows traffic information to be enabled or disabled  */
-  setTrafficEnabled(options: {
-    enabled: boolean,
-  }): Promise<any>;
+  setTrafficEnabled(options: { enabled: boolean }): Promise<any>;
 
   /** [iOS Only] To hide accessiblity elements  */
-  accessibilityElementsHidden(options: {
-    hidden: boolean,
-  }): Promise<any>;
+  accessibilityElementsHidden(options: { hidden: boolean }): Promise<any>;
 
   /** Adds padding around the map */
   padding(options: {
-    top: number,
-    left: number,
-    right: number,
-    bottom: number,
+    top: number;
+    left: number;
+    right: number;
+    bottom: number;
   }): Promise<any>;
 
   /** Clear any views like Marker, Shapes from the map */
@@ -89,35 +78,37 @@ export interface CapacitorGoogleMapsPlugin {
 
   /** Map UI Settings */
   settings(options: {
-    allowScrollGesturesDuringRotateOrZoom?: boolean,
-    compassButton?: boolean,
-    consumesGesturesInView?: boolean,
-    indoorPicker?: boolean,
-    myLocationButton?: boolean,
-    rotateGestures?: boolean,
-    scrollGestures?: boolean,
-    tiltGestures?: boolean,
-    zoomGestures?: boolean,
+    allowScrollGesturesDuringRotateOrZoom?: boolean;
+    compassButton?: boolean;
+    consumesGesturesInView?: boolean;
+    indoorPicker?: boolean;
+    myLocationButton?: boolean;
+    rotateGestures?: boolean;
+    scrollGestures?: boolean;
+    tiltGestures?: boolean;
+    zoomGestures?: boolean;
   }): Promise<any>;
 
   /** Get Google Map address for a set of lat lng */
   reverseGeocodeCoordinate(options: {
-    latitude: number,
-    longitude: number,
+    latitude: number;
+    longitude: number;
   }): Promise<any>;
 
   /** Enable user's current location */
-  enableCurrentLocation(options: {
-    enabled: boolean,
-  }): Promise<any>;
+  enableCurrentLocation(options: { enabled: boolean }): Promise<any>;
 
   /** Get user location */
   myLocation(options: any): Promise<any>;
 
+  /** Get view bounds in latlng. This polygon can be a trapezoid instead of a rectangle,
+   * because a camera can have tilt. If the camera is directly over the center of the
+   * camera, the shape is rectangular, but if the camera is tilted, the shape will
+   * appear to be a trapezoid whose smallest side is closest to the point of view. */
+  viewBounds(): Promise<any>;
+
   /** Add styles to map with a style JSON string format specific by Google */
-  setMapStyle(options: {
-    jsonString: string,
-  }): Promise<any>;
+  setMapStyle(options: { jsonString: string }): Promise<any>;
 
   /** Shapes */
   addPolyline(options: PolylineOptions): Promise<any>;
@@ -131,7 +122,6 @@ export interface CapacitorGoogleMapsPlugin {
   requestLocationPermission(): Promise<any>;
   setOnMyLocationClickListener(): Promise<any>;
   setOnMyLocationButtonClickListener(): Promise<any>;
-
 
   addListener(
     eventName: 'didTap',
@@ -157,5 +147,4 @@ export interface CapacitorGoogleMapsPlugin {
     eventName: 'onMapReady',
     listenerFunc: (results: any) => void
   ): PluginListenerHandle;
-
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -10,35 +10,35 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
   constructor() {
     super({
       name: 'CapacitorGoogleMaps',
-      platforms: ['web']
+      platforms: ['web'],
     });
   }
 
-  create(_options: { width: number; height: number; x: number; y: number; latitude?: number; longitude?: number; zoom?: number; liteMode?: boolean; }): Promise<any> {
+  create(_options: { width: number; height: number; x: number; y: number; latitude?: number; longitude?: number; zoom?: number; liteMode?: boolean }): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  initialize(_options: { key: string; }): Promise<any> {
+  initialize(_options: { key: string }): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  addMarker(_options: { latitude: number; longitude: number; opacity?: number; title?: string; snippet?: string; isFlat?: boolean; url?: string; }): Promise<any> {
+  addMarker(_options: { latitude: number; longitude: number; opacity?: number; title?: string; snippet?: string; isFlat?: boolean; url?: string }): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  setCamera(_options: { viewingAngle?: number; bearing?: number; zoom?: number; latitude?: number; longitude?: number; animate?: boolean; animationDuration?: number; coordinates?: LatLng[]; }): Promise<any> {
+  setCamera(_options: { viewingAngle?: number; bearing?: number; zoom?: number; latitude?: number; longitude?: number; animate?: boolean; animationDuration?: number; coordinates?: LatLng[] }): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  setMapType(_options: { type: string; }): Promise<any> {
+  setMapType(_options: { type: string }): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  setIndoorEnabled(_options: { enabled: boolean; }): Promise<any> {
+  setIndoorEnabled(_options: { enabled: boolean }): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  setTrafficEnabled(_options: { enabled: boolean; }): Promise<any> {
+  setTrafficEnabled(_options: { enabled: boolean }): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  accessibilityElementsHidden(_options: { hidden: boolean; }): Promise<any> {
+  accessibilityElementsHidden(_options: { hidden: boolean }): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  padding(_options: { top: number; left: number; right: number; bottom: number; }): Promise<any> {
+  padding(_options: { top: number; left: number; right: number; bottom: number }): Promise<any> {
     throw new Error('Method not implemented.');
   }
   clear(): Promise<any> {
@@ -53,19 +53,22 @@ export class CapacitorGoogleMapsWeb extends WebPlugin implements CapacitorGoogle
   show(): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  settings(_options: { allowScrollGesturesDuringRotateOrZoom?: boolean; compassButton?: boolean; consumesGesturesInView?: boolean; indoorPicker?: boolean; myLocationButton?: boolean; rotateGestures?: boolean; scrollGestures?: boolean; tiltGestures?: boolean; zoomGestures?: boolean; }): Promise<any> {
+  settings(_options: { allowScrollGesturesDuringRotateOrZoom?: boolean; compassButton?: boolean; consumesGesturesInView?: boolean; indoorPicker?: boolean; myLocationButton?: boolean; rotateGestures?: boolean; scrollGestures?: boolean; tiltGestures?: boolean; zoomGestures?: boolean }): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  reverseGeocodeCoordinate(_options: { latitude: number; longitude: number; }): Promise<any> {
+  reverseGeocodeCoordinate(_options: { latitude: number; longitude: number }): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  enableCurrentLocation(_options: { enabled: boolean; }): Promise<any> {
+  enableCurrentLocation(_options: { enabled: boolean }): Promise<any> {
     throw new Error('Method not implemented.');
   }
   myLocation(_options: any): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  setMapStyle(_options: { jsonString: string; }): Promise<any> {
+  viewBounds(): Promise<any> {
+    throw new Error('Method not implemented.');
+  }
+  setMapStyle(_options: { jsonString: string }): Promise<any> {
     throw new Error('Method not implemented.');
   }
   addPolyline(_options: PolylineOptions): Promise<any> {


### PR DESCRIPTION
Relates to https://github.com/capacitor-community/capacitor-googlemaps-native/issues/72


Added viewBounds object. I think getBounds() or something similar would be more clear naming here, but I know nothing else has a `getSomething` style of naming.

Prettier went a bit wild as well 🤦  on the .ts files, changing things like the comma on the interface to semicolons (default for linting/prettier) and removing last semi on objects. 

Returns data like below, where near is bottom and far is top. This is standard Google Maps naming as panning and tilting would make those areas the 'far and near' of screen.

```js
{
    "bounds": {
        "farLeft": {
            "latitude": 32.8635086678005,
            "longitude": -117.50440925359725
        },
        "farRight": {
            "latitude": 32.8635086678005,
            "longitude": -116.81776374578475
        },
        "nearLeft": {
            "latitude": 32.567717399290665,
            "longitude": -117.50440925359725
        },
        "nearRight": {
            "latitude": 32.567717399290665,
            "longitude": -116.81776374578475
        }
    }
}
```

*This still needs documentation on README.*
