### PR TITLE
✨ [android] fix bug by adding `handleOnStart` method

### DIFF
--- a/android/src/main/java/com/hemangkumar/capacitorgooglemaps/CapacitorGoogleMaps.java
+++ b/android/src/main/java/com/hemangkumar/capacitorgooglemaps/CapacitorGoogleMaps.java
@@ -76,6 +76,14 @@ public class CapacitorGoogleMaps extends Plugin implements OnMapReadyCallback, G
     }
 
     @Override
+    protected void handleOnStart() {
+        super.handleOnStart();
+        if (mapView != null) {
+            mapView.onStart();
+        }
+    }
+
+    @Override
     protected void handleOnResume() {
         super.handleOnResume();
         if (mapView != null) {


### PR DESCRIPTION
Because the `handleOnStart` lifecycle method was missing, sometimes the app would crash with this error message:

`java.lang.runtimeexception: Unable to stop activity`

This PR fixes that.