### PR TITLE
Update README for Capacitor 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ You'll have two API keys by the end of this step. Lets proceed:
 
 ### Add API key to your App
 
-- [Android](https://developers.google.com/maps/documentation/android-sdk/get-api-key) in AndroidManifest.xml:
+#### Android
+[Android](https://developers.google.com/maps/documentation/android-sdk/get-api-key) in AndroidManifest.xml:
 ```
 <application>
 ...
@@ -91,6 +92,23 @@ You'll have two API keys by the end of this step. Lets proceed:
 ...
 </application>
 ```
+As of [Capacitor 3](https://capacitorjs.com/docs/updating/3-0), the plugin needs to be regitered in MainActivity.java:
+```java
+import com.hemangkumar.capacitorgooglemaps.CapacitorGoogleMaps;
+//...
+
+public class MainActivity extends BridgeActivity {
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // ...
+    registerPlugin(CapacitorGoogleMaps.class);
+  }
+}
+
+```
+#### iOS
 - On iOS, this step is little different and mentioned below.
 
 ### Importing & Initializing the plugin
@@ -112,13 +130,13 @@ await CapacitorGoogleMaps.initialize({
 
 `component.html`
 
-```
+```html
 <div id="map" #map></div>
 ```
 
 `component.css`
 
-```
+```css
 #map {
     margin: 2em 1em;
     height: 250px;

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You'll have two API keys by the end of this step. Lets proceed:
 ...
 </application>
 ```
-As of [Capacitor 3](https://capacitorjs.com/docs/updating/3-0), the plugin needs to be regitered in MainActivity.java:
+As of [Capacitor 3](https://capacitorjs.com/docs/updating/3-0), the plugin needs to be registered in MainActivity.java:
 ```java
 import com.hemangkumar.capacitorgooglemaps.CapacitorGoogleMaps;
 //...


### PR DESCRIPTION
Capacitor 3 requires this plugin be registered for Android [in the new way](https://capacitorjs.com/docs/updating/3-0#switch-to-automatic-android-plugin-loading), otherwise you will get the JS console error

`ERROR Error: Uncaught (in promise): Error: "CapacitorGoogleMaps" plugin is not implemented on android Error: "CapacitorGoogleMaps" plugin is not implemented on android`

Stumbled upon the solution from [here](https://github.com/ionic-team/capacitor/discussions/3994#discussioncomment-1021185) and figured it will be helpful to have this updated to let other people avoid the issue here.

Added the html and css types to the code blocks because why not