### PR TITLE
Fix crash with empty map

### DIFF
--- a/android/src/main/java/com/hemangkumar/capacitorgooglemaps/CapacitorGoogleMaps.java
+++ b/android/src/main/java/com/hemangkumar/capacitorgooglemaps/CapacitorGoogleMaps.java
@@ -417,8 +417,12 @@ public class CapacitorGoogleMaps extends Plugin implements OnMapReadyCallback, G
         getBridge().executeOnMainThread(new Runnable() {
             @Override
             public void run() {
-                View viewToRemove = ((ViewGroup) getBridge().getWebView().getParent()).findViewById(mapViewParentId);
-                ((ViewGroup) getBridge().getWebView().getParent()).removeViewInLayout(viewToRemove);
+                if (mapViewParentId != null){
+                    View viewToRemove = ((ViewGroup) getBridge().getWebView().getParent()).findViewById(mapViewParentId);
+                    if (viewToRemove != null){
+                        ((ViewGroup) getBridge().getWebView().getParent()).removeViewInLayout(viewToRemove);
+                    }
+                }
             }
         });
     }
@@ -428,8 +432,12 @@ public class CapacitorGoogleMaps extends Plugin implements OnMapReadyCallback, G
         getBridge().executeOnMainThread(new Runnable() {
             @Override
             public void run() {
-                View viewToHide = ((ViewGroup) getBridge().getWebView().getParent()).findViewById(mapViewParentId);
-                viewToHide.setVisibility(View.INVISIBLE);
+                if (mapViewParentId != null){
+                    View viewToHide = ((ViewGroup) getBridge().getWebView().getParent()).findViewById(mapViewParentId);
+                    if (viewToHide != null){
+                        viewToHide.setVisibility(View.INVISIBLE);
+                    }
+                }
             }
         });
     }
@@ -439,8 +447,12 @@ public class CapacitorGoogleMaps extends Plugin implements OnMapReadyCallback, G
         getBridge().executeOnMainThread(new Runnable() {
             @Override
             public void run() {
-                View viewToShow = ((ViewGroup) getBridge().getWebView().getParent()).findViewById(mapViewParentId);
-                viewToShow.setVisibility(View.VISIBLE);
+                if (mapViewParentId != null){
+                    View viewToShow = ((ViewGroup) getBridge().getWebView().getParent()).findViewById(mapViewParentId);
+                    if (viewToRemove != null){
+                        viewToShow.setVisibility(View.VISIBLE);
+                    }
+                }
             }
         });
     }

--- a/android/src/main/java/com/hemangkumar/capacitorgooglemaps/CapacitorGoogleMaps.java
+++ b/android/src/main/java/com/hemangkumar/capacitorgooglemaps/CapacitorGoogleMaps.java
@@ -191,6 +191,11 @@ public class CapacitorGoogleMaps extends Plugin implements OnMapReadyCallback, G
         final Boolean isFlat = call.getBoolean("isFlat", true);
         final JSObject metadata = call.getObject("metadata");
 
+        if (googleMap == null){
+            call.reject("Map is not ready");
+            return;
+        }
+
         getBridge().getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -68,6 +68,11 @@ public class CapacitorGoogleMaps: CAPPlugin, GMSMapViewDelegate, GMSPanoramaView
         let url = URL(string: call.getString("iconUrl", ""))
         var imageData: Data?
 
+        if self.mapViewController == nil {
+            call.reject("Map is not ready")
+            return
+        }
+
         DispatchQueue.global().async {
 
             if url != nil {


### PR DESCRIPTION
When working on an uninitialized map (non created), avoid crash on close/show/hide and rejects to add a marker.



    
