### PR TITLE
fix(definitions) add metadata property to marker options

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -31,6 +31,7 @@ export interface CapacitorGoogleMapsPlugin {
     isFlat?: boolean;
     iconUrl?: string;
     draggable?: boolean;
+    metadata?: object;
   }): Promise<any>;
 
   /** Removes a marker on the map */


### PR DESCRIPTION
Feel like it's missing metadata definition in marker options